### PR TITLE
Add escape for configuration panel

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -107,19 +107,35 @@ __END__
 
 %div.row
   %section.twelve
-    %h4 Format
+    %h4 Configuration
     %p Copy and paste to <code>fluent.conf</code> or <code>td-agent.conf</code>
     %div.panel
-      %span format /#{@regexp}/
+      & &lt;source&gt;
+      %br/
+      & &nbsp;&nbsp;type tail
+      %br/
+      & &nbsp;&nbsp;path /var/log/foo/bar.log
+      %br/
+      & &nbsp;&nbsp;pos_file /var/log/td-agent/foo-bar.log.pos
+      %br/
+      & &nbsp;&nbsp;tag foo.bar
+      %br/
+      & &nbsp;&nbsp;format /#{@regexp}/
       %br/
       - if @time_format and !@time_format.empty?
-        %span time_format #{@time_format}
+        & &nbsp;&nbsp;time_format #{@time_format}
+        %br/
+      & &lt;/source&gt;
 
 %div.row
   %section
     %h4 Data Inspector
     %h5 Attribute
     %table.twelve
+      %thead
+        %tr
+          %th.four Key
+          %th.eight Value
       %tbody
         - if @parsed
           %tr


### PR DESCRIPTION
I've found a problem to lack of html escape for showing regexp.

e.g. [parsed example](http://fluentular.herokuapp.com/parse?regexp=%5E%5C%5B%28%3F%3Ctime%3E%5B%5E+%5D*+%5B%5E+%5D*%29%5C%5D%5C%5B%28%3F%3Clevel%3E%5B%5E+%5D*%29+*%3F%5C%5D%5C%5B%28%3F%3Ccluster_name%3E%5B%5E+%5D*%29+*%5C%5D+%5C%5B%28%3F%3Cnode_name%3E%5B%5E+%5D*%29+*%5C%5D%28%3F%3Cmessage%3E.*%29&input=%5B2013-11-27+13%3A02%3A51%2C436%5D%5BTRACE%5D%5Bindex.search.slowlog.query%5D+%5Bh35%5D+%5Bcms%5D%5B2%5D+took%5B1.1s%5D%2C+took_millis%5B1136%5D%2C+types%5Bnews%5D%2C+stats%5B%5D%2C+search_type%5BQUERY_THEN_FETCH%5D%2C+total_shards%5B10%5D%2C+source%5B%7B%22from%22%3A250%2C%22size%22%3A10%2C%22query%22%3A%7B%22custom_score%22%3A%7B%22query%22%3A%7B%22filtered%22%3A%7B%22query%22%3A%7B%22query_string%22%3A%7B%22query%22%3A%22%E5%B0%BC%E6%97%A5%E5%88%A9%E4%BA%9A%22%2C%22fields%22%3A%5B%22title%22%2C%22content%22%5D%2C%22analyzer%22%3A%22ik%22%7D%7D%2C%22filter%22%3A%7B%22bool%22%3A%7B%22must%22%3A%7B%22range%22%3A%7B%22updatetime%22%3A%7B%22from%22%3A1353992570%2C%22to%22%3A1385528570%2C%22include_lower%22%3Atrue%2C%22include_upper%22%3Atrue%7D%7D%7D%7D%7D%7D%7D%2C%22script%22%3A%22long+x%3DLong.parseLong%28doc%5B%27updatetime%27%5D.value%29%3Bx%3Dx%2F86400l%3Blong+nows%3Dyy%2F86400l%3Bint+nowDay%3D%28int%29nows%3Bint+day%3D%28int%29x%3Bif+%28day+%3C+nowDay%29+%7Bint+temp%3DnowDay-day%3Bint+delta%3D%28int%29temp%2F5%2B1%3Bif%28delta%3C32%29%7B_score%3D_score%2B6*pow%280.9%2Cdelta%29%3B%7Delse%7B_score%3D_score%2B3*pow%280.9%2C31%29%3B%7D%7D+else+if+%28day+%3E+nowDay%29+%7B_score%3D_score%2B3*pow%280.9%2C31%29%3B%7D+else%7B_score%3D_score%2B3%3B%7D%22%2C%22params%22%3A%7B%22yy%22%3A1385528570%7D%7D%7D%2C%22fields%22%3A%5B%22id%22%2C%22channelid%22%2C%22catid%22%2C%22model%22%2C%22title%22%2C%22content%22%2C%22thumb%22%2C%22url%22%2C%22updatetime%22%5D%2C%22sort%22%3A%5B%7B%22_score%22%3A%7B%22order%22%3A%22desc%22%7D%7D%2C%7B%22updatetime%22%3A%7B%22order%22%3A%22desc%22%7D%7D%5D%2C%22highlight%22%3A%7B%22pre_tags%22%3A%5B%22%3Cem%3E%22%5D%2C%22post_tags%22%3A%5B%22%3C%2Fem%3E%22%5D%2C%22encoder%22%3A%22UTF-8%22%2C%22fields%22%3A%7B%22title%22%3A%7B%7D%2C%22content%22%3A%7B%22fragment_size%22%3A72%2C%22number_of_fragments%22%3A3%7D%7D%7D%7D%5D%2C+extra_source%5B%5D&time_format=)
- expect

`format /^\[(?<time>[^ ]* [^ ]*)\]\[(?<level>[^ ]*) *?\]\[(?<cluster_name>[^ ]*) *\] \[(?<node_name>[^ ]*) *\](?<message>.*)/`
- current

`format /^\[(?[^ ]* [^ ]*)\]\[(?[^ ]*) *?\]\[(?[^ ]*) *\] \[(?[^ ]*) *\](?.*)/`
