### PR TITLE
Add CGI.escapeHTML for record inspector

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -155,8 +155,8 @@ __END__
         - if @parsed
           - @parsed.each do |key, value|
             %tr
-              %th= key
-              %td= value
+              %th #{CGI.escapeHTML(key)}
+              %td #{CGI.escapeHTML(value)}
         - else
           %tr
             %th 


### PR DESCRIPTION
Hi, I have add CGI.escapeHTML for record inspector panel.
It may cause XSS problem for current version.

e.g. [it could use any tag](http://fluentular.herokuapp.com/parse?regexp=%5E%5C%5B%28%3F%3Ctime%3E%5B%5E+%5D*+%5B%5E+%5D*%29%5C%5D%5C%5B%28%3F%3Clevel%3E%5B%5E+%5D*%29+*%3F%5C%5D%5C%5B%28%3F%3Ccluster_name%3E%5B%5E+%5D*%29+*%5C%5D+%5C%5B%28%3F%3Cnode_name%3E%5B%5E+%5D*%29+*%5C%5D%28%3F%3Cmessage%3E.*%29&input=%5B2013-11-27+13%3A02%3A51%2C436%5D%5BTRACE%5D%5Bindex.search.slowlog.query%5D+%5Bh35%5D+%3Ch1%3Eit+could+use+any+tag%3C%2Fh1%3E&time_format=)
