### PR TITLE
Trim needless slash input for Regular Expression

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -13,7 +13,7 @@ get '/' do
 end
 
 get '/parse' do
-  @regexp = params[:regexp]
+  @regexp = params[:regexp].gsub(/^\/(.+)\/$/, '\1')
   @input  = params[:input]
   @time_format = params[:time_format]
 


### PR DESCRIPTION
How about to trim needless slash for `Regular Expression` input automaticaly?

It comes work like this pattern.
e.g. [start-and-end-letter-has-slash-regexp sample at fluentular.herokuapp.com](http://fluentular.herokuapp.com/parse?regexp=%2F%5E%5C%5B%28%3F%3Ctime%3E%5B%5E+%5D*+%5B%5E+%5D*%29%5C%5D%5C%5B%28%3F%3Clog_level%3E%5B%5E+%5D*%29+*%3F%5C%5D%5C%5B%28%3F%3Clog_type%3E%5B%5E+%5D*%29+*%5C%5D+%5C%5B%28%3F%3Cnode_name%3E%5B%5E+%5D*%29+*%5C%5D+%28%3F%3Cmessage%3E.*%29%24%2F&input=%5B2014-03-18+18%3A27%3A34%2C897%5D%5BINFO+%5D%5Bhttp+++++++++++++++++++++%5D+%5Bes01%5D+bound_address+%7Binet%5B%2F0%3A0%3A0%3A0%3A0%3A0%3A0%3A0%3A9200%5D%7D%2C+publish_address+%7Binet%5B%2F10.0.0.185%3A9200%5D%7D&time_format=%25Y-%25m-%25d+%25H%3A%25M%3A%25S)
