### PR TITLE
Call configure to initialize TimeParser correctly

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -19,7 +19,7 @@ get '/parse' do
 
   begin
     parser = Fluent::TextParser::RegexpParser.new(Regexp.new(@regexp))
-    parser.time_format = @time_format if not @time_format.empty?
+    parser.configure('time_format' => @time_format) if not @time_format.empty?
     @parsed_time, @parsed = parser.call(@input)
   rescue
     @parsed_time = @parsed = nil


### PR DESCRIPTION
I noticed this bug from Fluentd ML.

https://groups.google.com/d/msg/fluentd/gQbJbF5w9QM/j0zqhZbIZ1wJ
