### PR TITLE
Explicitly enable inline-templates

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -10,6 +10,8 @@ require 'fluent/parser'
 
 set :haml, format: :html5
 
+enable :inline_templates
+
 get '/' do
   haml :index
 end


### PR DESCRIPTION
Was seeing "Application Error" a bunch on Heroku. Tried to run the app myself by using `Rack::Server.start(config: 'app.rb')` on my machine, and haml kept looking for actual file templates. This change explicitly tells Sinatra "yo, the templates are in this file, check 'em out"