### PR TITLE
Switch Heroku deployment to Ruby buildpack and isolate Docker for distribution

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,11 @@
 {
   "name": "Fluentular Dev Environment",
   "image": "mcr.microsoft.com/devcontainers/ruby:4",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:3": {
+      "moby": false
+    }
+  },
   "containerEnv": {
     "BUNDLE_PATH": "/usr/local/bundle",
     "TZ": "Asia/Tokyo"

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec rackup --host 0.0.0.0 -p ${PORT}

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,6 +1,0 @@
-build:
-  languages:
-    - ruby
-
-run:
-  web: bundle exec rackup config.ru -p ${PORT}


### PR DESCRIPTION
### Background
Initially, this PR attempted to migrate the Heroku deployment to a Docker-based pipeline (container stack via heroku.yml). However, the ENTRYPOINT ["bundle"] in our Dockerfile—which is highly optimized for DockerHub distribution—conflicted with Heroku's internal container runtime wrapper (/bin/sh -c), causing startup crashes.

### Solution
To keep the Dockerfile clean and pristine for future DockerHub/GHCR distribution without dirtying it with Heroku-specific workarounds, we changed our strategy to fall back to Heroku's standard Ruby Buildpack (heroku-26).

### Changes
- **.devcontainer/devcontainer.json**: Added the docker-in-docker feature to support local Docker testing within Codespaces.
- **Procfile**: Re-introduced to explicitly define the web process command (bundle exec rackup) for the Heroku Buildpack.
- **heroku.yml**: Deleted, as we are no longer using Manifest-based Docker deploys on Heroku.
- **app.json**: Kept "stack": "heroku-26" to leverage the latest standard Heroku stack.

### Testing
- Verified that the Heroku Review App builds successfully using the Ruby Buildpack and launches the Rack application without any /bin/sh or Bundler conflicts.